### PR TITLE
feat: add Cacharr service support

### DIFF
--- a/constants/enums.js
+++ b/constants/enums.js
@@ -23,6 +23,7 @@ export const SERVICE_KEY = {
   RCLONE: "rclone",
   RIVEN_BE: "riven_backend",
   RIVEN_FE: "riven_frontend",
+  CACHARR: "cacharr",
   SEERR: "seerr",
   SONARR: "sonarr",
   TAUTULLI: "tautulli",

--- a/helper/ServiceTypeLP.js
+++ b/helper/ServiceTypeLP.js
@@ -82,6 +82,7 @@ export function serviceTypeLP({ logsRaw, serviceKey, processName, projectName })
   if (serviceKey === SERVICE_KEY.PLEX) return parsePlexLogs(logsRaw, processName)
   if (serviceKey === SERVICE_KEY.DECYPHARR) return parseDecypharrLogs(logsRaw, processName);
   if (serviceKey === SERVICE_KEY.ZILEAN) return parseZileanLogs(logsRaw, processName);
+  if (serviceKey === SERVICE_KEY.CACHARR) return parseCacharrLogs(logsRaw, processName);
 }
 
 const parseHuntarrLogs = (logsRaw, processName) => {
@@ -776,5 +777,33 @@ const parseCliBatteryLogs = (logsRaw, processName) => {
   // Push the last entry if any
   if (currentEntry) parsedLogs.push(currentEntry);
 
+  return parsedLogs;
+};
+
+// "2026-03-19 10:23:45,123 [hunter] INFO Some message"
+const parseCacharrLogs = (logsRaw, processName) => {
+  const lines = logsRaw.trim().split('\n');
+  const parsedLogs = [];
+  const logLineRegex = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d+ \[\w+\] (\w+) (.*)$/;
+  const fallbackProcess = processName?.trim().replace(' subprocess', '') || 'Cacharr';
+  let currentEntry = null;
+
+  for (const line of lines) {
+    const match = line.match(logLineRegex);
+    if (match) {
+      if (currentEntry) parsedLogs.push(currentEntry);
+      const [, timestampStr, level, message] = match;
+      currentEntry = {
+        timestamp: new Date(timestampStr),
+        level: level.trim(),
+        process: fallbackProcess,
+        message: message.trim(),
+      };
+    } else if (currentEntry) {
+      currentEntry.message += '\n' + line;
+    }
+  }
+
+  if (currentEntry) parsedLogs.push(currentEntry);
   return parsedLogs;
 };


### PR DESCRIPTION
## Summary

Adds frontend support for **Cacharr** — the Riven stuck-item rescue daemon added to DUMB in [I-am-PUID-0/DUMB#165](https://github.com/I-am-PUID-0/DUMB/pull/165).

- `constants/enums.js` — adds `CACHARR: "cacharr"` to `SERVICE_KEY` so the service is recognised throughout the UI
- `helper/ServiceTypeLP.js` — adds `parseCacharrLogs` and wires it into `serviceTypeLP`; parses Cacharr's Python logging format:
  ```
  2026-03-19 10:23:45,123 [hunter] INFO Starting cycle...
  2026-03-19 10:23:46,456 [hunter] WARNING No results for Show Name S02
  ```

## What Cacharr does

Cacharr runs as a DUMB service (port 8484) that rescues items stuck in Riven's `Scraped`/`Failed`/`Indexed` states by searching Prowlarr for torrents and submitting them to RealDebrid to trigger server-side caching. Nothing downloads locally. Full details in the companion DUMB PR.

## Test plan

- [ ] Enable Cacharr in DUMB config (`CACHARR_ENABLED=true`)
- [ ] Confirm Cacharr appears in the DUMB UI service list
- [ ] Open Cacharr logs panel — confirm lines parse with correct timestamp, level, and message
- [ ] Confirm start/stop/restart controls work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)